### PR TITLE
Add cleanup unused stacks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     compile group: 'javax.inject', name: 'javax.inject', version: '1'
     compile group: 'org.apache.commons', name: 'commons-exec', version: '1.3'
     compile group: 'org.webjars', name: 'jquery', version: '3.2.1'
+    compile('org.springframework.boot:spring-boot-starter-mail')
     compile 'com.beust:klaxon:0.30'
     testCompile group: 'org.jetbrains.kotlin', name: 'kotlin-test-junit', version: '1.1.3-2'
     testCompile 'org.springframework.boot:spring-boot-starter-test'

--- a/data/templates/mysql/script.tf
+++ b/data/templates/mysql/script.tf
@@ -3,6 +3,7 @@ provider "docker" {
 
 resource "docker_image" "mysql" {
   name = "mysql/mysql-server:${var.version}"
+  keep_locally = true
 }
 
 resource "docker_container" "mysql" {
@@ -22,5 +23,5 @@ resource "docker_container" "mysql" {
 }
 
 output "link" {
-  value = "/testenv.labs.intellij.net:${var.external_port}"
+  value = "testenv.labs.intellij.net:${var.external_port}"
 }

--- a/src/main/kotlin/ru/jetbrains/testenvrunner/TestEnvRunnerApplication.kt
+++ b/src/main/kotlin/ru/jetbrains/testenvrunner/TestEnvRunnerApplication.kt
@@ -3,9 +3,11 @@ package ru.jetbrains.testenvrunner
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.autoconfigure.security.oauth2.client.EnableOAuth2Sso
+import org.springframework.scheduling.annotation.EnableScheduling
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 
+@EnableScheduling
 @EnableOAuth2Sso
 @SpringBootApplication
 class TestEnvRunnerApplication : WebSecurityConfigurerAdapter() {
@@ -20,10 +22,8 @@ class TestEnvRunnerApplication : WebSecurityConfigurerAdapter() {
                 .and().logout().logoutSuccessUrl("/").permitAll()
                 .and().csrf().disable()
     }
-
 }
 
 fun main(args: Array<String>) {
     SpringApplication.run(TestEnvRunnerApplication::class.java, *args)
-
 }

--- a/src/main/kotlin/ru/jetbrains/testenvrunner/model/DatabaseModels.kt
+++ b/src/main/kotlin/ru/jetbrains/testenvrunner/model/DatabaseModels.kt
@@ -2,10 +2,15 @@ package ru.jetbrains.testenvrunner.model
 
 import org.springframework.data.annotation.Id
 import org.springframework.data.annotation.PersistenceConstructor
+import java.util.*
 
 data class User @PersistenceConstructor constructor(val name: String, @Id val email: String,
                                                     var listOfStacks: MutableList<String>)
 
-data class Stack @PersistenceConstructor constructor(val name: String, val createdDate: String, val user: User)
+data class Stack @PersistenceConstructor constructor(@Id val name: String,
+                                                     val user: User,
+                                                     val createdDate: Date,
+                                                     var notificationDate: Date,
+                                                     var expiredDate: Date)
 
 

--- a/src/main/kotlin/ru/jetbrains/testenvrunner/sheduler/SheduledCleanup.kt
+++ b/src/main/kotlin/ru/jetbrains/testenvrunner/sheduler/SheduledCleanup.kt
@@ -1,0 +1,48 @@
+package ru.jetbrains.testenvrunner.sheduler
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.mail.javamail.JavaMailSender
+import org.springframework.mail.javamail.MimeMessageHelper
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import ru.jetbrains.testenvrunner.model.Stack
+import ru.jetbrains.testenvrunner.service.StackService
+
+@Component
+class ScheduledCleanup constructor(val stackService: StackService,
+                                   val sender: JavaMailSender,
+                                   @Value("\${web_address}") val webAddress: String) {
+
+    val relativeAddress = "/stack/%s/prolong"
+
+    @Scheduled(cron = "0/10 * * * * *")
+    fun cleanupStacks() {
+        notifyUsers()
+        destroyExpiredStacks()
+    }
+
+    private fun sendEmail(stack: Stack) {
+        val message = sender.createMimeMessage()
+        val helper = MimeMessageHelper(message)
+
+        helper.setTo(stack.user.email)
+        helper.setSubject(
+                "Terraform Script Executor. The stack ${stack.name} will be deleted soon.\n")
+        helper.setText("The stack ${stack.name} will be deleted soon.\n" +
+                "Please follow the next link " +
+                "$webAddress${relativeAddress.format(
+                        stack.name)} to prolong the stack for ${stackService.expireDate} days")
+
+        sender.send(message)
+    }
+
+    fun notifyUsers() {
+        val notifiedStacks = stackService.getNotifyStacks()
+        notifiedStacks.forEach { sendEmail(it); stackService.updateNotificationDates(it) }
+    }
+
+    fun destroyExpiredStacks() {
+        val expiredStacks = stackService.getExpiredStacks()
+        expiredStacks.forEach { stackService.destroyStackSync(it.name) }
+    }
+}

--- a/src/main/kotlin/ru/jetbrains/testenvrunner/utils/DateUtils.kt
+++ b/src/main/kotlin/ru/jetbrains/testenvrunner/utils/DateUtils.kt
@@ -11,8 +11,16 @@ class DateUtils {
      * Get current date as String
      * @return Current date in "HH:mm dd/MM/yy" format
      */
-    fun getCurrentDate(): String {
+    fun getCurrentDateAsString(): String {
         return dateFormat.format(Date())
+    }
+
+    /**
+     * Get current date
+     * @return Current date in "HH:mm dd/MM/yy" format
+     */
+    fun getCurrentDate(): Date {
+        return Date()
     }
 
     /**
@@ -22,5 +30,12 @@ class DateUtils {
      */
     fun parseDate(stringDate: String): Date {
         return dateFormat.parse(stringDate)
+    }
+
+    fun addDaysToDate(date: Date, days: Int): Date {
+        val c = Calendar.getInstance()
+        c.time = date
+        c.add(Calendar.DATE, days) //same with c.add(Calendar.DAY_OF_MONTH, 1);
+        return c.time ?: throw Exception("the exception in Java calendar")
     }
 }

--- a/src/main/resources/application-container.yaml
+++ b/src/main/resources/application-container.yaml
@@ -1,12 +1,15 @@
 stacks: ./data/stacks
 templates: ./data/templates
 
+expire_day: ${EXPIRE_DAY}
+notify_day: ${NOTIFY_DAY}
+web_address: ${WEB_ADDRESS}
 
 security:
   oauth2:
     client:
       clientId: 759913667428-fnjj8ofelfk9asa0lnoadrnqun5l5veo.apps.googleusercontent.com
-      clientSecret: ZwLBr4iqlscXdfD7hFK7_-Dy
+      clientSecret: ${OAUTH2_SECRET}
       accessTokenUri: https://www.googleapis.com/oauth2/v4/token
       userAuthorizationUri: https://accounts.google.com/o/oauth2/v2/auth
       clientAuthenticationScheme: form
@@ -17,9 +20,23 @@ security:
     resource:
       userInfoUri: https://www.googleapis.com/oauth2/v3/userinfo
       preferTokenInfo: true
-
 spring:
   data:
-     mongodb:
-       host: ${DB_HOST}
-       port: 27017
+    mongodb:
+      host: ${DB_HOST}
+      port: 27017
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+            required: true
+          auth: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    username: ${EMAIL_LOGIN}
+    password: ${EMAIL_PASSWORD}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,12 +1,15 @@
 stacks: ./data/stacks
 templates: ./data/templates
 
+expire_day: 5
+notify_day: 4
+web_address: 127.0.0.1:8080
 
 security:
   oauth2:
     client:
       clientId: 759913667428-fnjj8ofelfk9asa0lnoadrnqun5l5veo.apps.googleusercontent.com
-      clientSecret: ZwLBr4iqlscXdfD7hFK7_-Dy
+      clientSecret: ${OAUTH2_SECRET}
       accessTokenUri: https://www.googleapis.com/oauth2/v4/token
       userAuthorizationUri: https://accounts.google.com/o/oauth2/v2/auth
       clientAuthenticationScheme: form
@@ -22,3 +25,18 @@ spring:
     mongodb:
       host: localhost
       port: 27017
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+            required: true
+          auth: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+    username: ${EMAIL_LOGIN}
+    password: ${EMAIL_PASSWORD}

--- a/src/main/resources/templates/running_script.html
+++ b/src/main/resources/templates/running_script.html
@@ -18,6 +18,11 @@
     </div>
     <div class="row">
         <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+            <!--/*@thymesVar id="msg" type="java.lang.String"*/-->
+            <div class="alert alert-success" th:if="${msg != null}">
+                <strong th:text="${msg}">The stack is prolonged!</strong>
+            </div>
+
             <!--/*@thymesVar id="stack" type="ru.jetbrains.testenvrunner.model.Stack"*/-->
             <h2><b>Stack:</b> <span th:text="${stack.name}"> Ubuntu</span></h2>
 
@@ -26,12 +31,10 @@
                 <b>Usage link:</b>
                 <a href="/" th:if="${not link.isEmpty()}" th:href="${link}" th:text="${link}">URL: localhost:8080</a>
                 <span th:if="${link.isEmpty()}">The link does not exist</span>
-
-            </p>
-
-
-            <p>
+                <br/>
                 <b>Creation date:</b> <span th:text="${stack.createdDate}">14:34 23/05/2016</span>
+                <br/>
+                <b>Expired date:</b> <span th:text="${stack.expiredDate}">14:34 23/05/2016</span>
                 <br/>
             </p>
             <p th:if="${stack.user!=null}">
@@ -53,8 +56,8 @@
                 <button name="script-name" th:value="${stack.name}"
                         class="btn btn-sm btn-info btn-danger">Destroy
                 </button>
+                <input type="hidden" name="action" value="destroy"/>
             </form>
-
         </div>
     </div>
 </div>

--- a/src/test/kotlin/ru/jetbrains/testenvrunner/utils/DateTest.kt
+++ b/src/test/kotlin/ru/jetbrains/testenvrunner/utils/DateTest.kt
@@ -9,10 +9,9 @@ class DateTest : Assert() {
     val dateFormat = SimpleDateFormat("HH:mm dd/MM/yy")
     @Test
     fun getCurrentDateTest() {
-        val curDateString = dateUtil.getCurrentDate()
+        val curDateString = dateUtil.getCurrentDateAsString()
         val date = dateUtil.parseDate(curDateString)
         dateFormat.format(date)
-
 
         assertEquals("The date is not the same", curDateString, dateFormat.format(date))
     }


### PR DESCRIPTION
User can run a stack and forget about it.
This stack will handle some limited resources. Fo this reason,
the system should notify author of running stacks about expire date
by email, and provide an opportunity to prolong the life time of the stack.
If the author ignores email, the stack should be destroyed.