### PR TITLE
Add select list of available version of docker images

### DIFF
--- a/data/templates/mysql/variables.tf.json
+++ b/data/templates/mysql/variables.tf.json
@@ -1,7 +1,7 @@
 {
   "variable": {
     "version": {
-      "default": "latest"
+      "description": "tags:mysql/mysql-server"
     },
     "external_port": {
       "default": "3306"

--- a/data/templates/nginx/variables.tf.json
+++ b/data/templates/nginx/variables.tf.json
@@ -1,7 +1,7 @@
 {
   "variable": {
     "version": {
-      "default": "1.11-alpine"
+      "description": "tags:nginx"
     },
     "external_port": {
       "default": "8080"

--- a/data/templates/ubuntu/script.tf
+++ b/data/templates/ubuntu/script.tf
@@ -1,7 +1,7 @@
 provider "docker" {
 }
 resource "docker_image" "ubuntu" {
-  name = "ubuntu:precise"
+  name = "ubuntu:${var.version}"
 }
 resource "docker_container" "ubuntu" {
   name = "ubuntu-server"

--- a/data/templates/ubuntu/variables.tf.json
+++ b/data/templates/ubuntu/variables.tf.json
@@ -1,0 +1,7 @@
+{
+  "variable": {
+    "version": {
+      "description": "tags:ubuntu"
+    }
+  }
+}

--- a/src/main/kotlin/ru/jetbrains/testenvrunner/controller/IndexController.kt
+++ b/src/main/kotlin/ru/jetbrains/testenvrunner/controller/IndexController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import ru.jetbrains.testenvrunner.repository.ExecutingStacksRepository
 import ru.jetbrains.testenvrunner.repository.TemplateRepository
+import ru.jetbrains.testenvrunner.service.DockerHubService
 import ru.jetbrains.testenvrunner.service.StackService
 import ru.jetbrains.testenvrunner.service.UserService
 import javax.servlet.http.HttpServletRequest
@@ -20,7 +21,8 @@ class IndexController constructor(
         val userService: UserService,
         val stackService: StackService,
         val templateRepository: TemplateRepository,
-        val executingStacks: ExecutingStacksRepository) {
+        val executingStacks: ExecutingStacksRepository,
+        val dockerHubService: DockerHubService) {
 
     @RequestMapping(method = arrayOf(RequestMethod.GET))
     fun indexGet(model: Model, auth: OAuth2Authentication?): String {
@@ -65,6 +67,7 @@ class IndexController constructor(
             params = arrayOf("action=run", "script-name"))
     fun openScriptRunForm(model: Model, @RequestParam(value = "script-name") templateName: String): String {
         val terraformScript = templateRepository.get(templateName)
+        dockerHubService.fillAvailableDockerTags(terraformScript)
         model.addAttribute("script", terraformScript)
         return "run_param"
     }

--- a/src/main/kotlin/ru/jetbrains/testenvrunner/model/MemoryModels.kt
+++ b/src/main/kotlin/ru/jetbrains/testenvrunner/model/MemoryModels.kt
@@ -3,7 +3,32 @@ package ru.jetbrains.testenvrunner.model
 import ru.jetbrains.testenvrunner.utils.ExecuteResultHandler
 import java.io.File
 
-data class TerraformScript(val scriptDir: File, val params: Map<String, Any?> = emptyMap()) {
+fun createTerraformParam(name: String, param: Map<String, Any?>): TerraformScriptParam {
+    return TerraformScriptParam(name = name,
+            value = param["value"] as String? ?: "",
+            defaultValue = param["default"] as String? ?: "",
+            description = param["description"] as String? ?: ""
+    )
+}
+
+data class TerraformScriptParam(val name: String,
+                                val value: String = "",
+                                val defaultValue: String = "",
+                                val description: String = "") {
+
+    val dockerHub: String get() {
+        val SIGN_OF_DOCKER_HUB = "tags:"
+        val lowerDescription = description.toLowerCase()
+        if (!lowerDescription.contains(SIGN_OF_DOCKER_HUB)) return ""
+        return lowerDescription.substringAfter(SIGN_OF_DOCKER_HUB)
+    }
+
+    var availableValues: List<String> = emptyList()
+}
+
+class TerraformScriptParams : ArrayList<TerraformScriptParam>()
+
+data class TerraformScript(val scriptDir: File, val params: TerraformScriptParams) {
     val absolutePath: String
         get() = scriptDir.canonicalPath
     val name: String

--- a/src/main/kotlin/ru/jetbrains/testenvrunner/repository/ScriptRepository.kt
+++ b/src/main/kotlin/ru/jetbrains/testenvrunner/repository/ScriptRepository.kt
@@ -1,0 +1,59 @@
+package ru.jetbrains.testenvrunner.repository
+
+import com.beust.klaxon.JsonObject
+import com.beust.klaxon.Parser
+import org.springframework.stereotype.Repository
+import ru.jetbrains.testenvrunner.model.TerraformScript
+import ru.jetbrains.testenvrunner.model.TerraformScriptParams
+import ru.jetbrains.testenvrunner.model.createTerraformParam
+import java.io.File
+import java.io.FileFilter
+
+@Repository
+abstract class ScriptRepository constructor(val scriptFolder: String) {
+    val MSG_DIR_DOES_NOT_EXIST = "The script %s does not exist in the system"
+
+    /**
+     * Get all scripts in folder
+     * @return available scripts
+     */
+    fun getAll(): List<TerraformScript> {
+        val directories = File(scriptFolder).listFiles(FileFilter { it.isDirectory })
+        val scripts = directories.map { TerraformScript(it, getParam(it.name)) }
+        return scripts.toList()
+    }
+
+    /**
+     * Get script by name
+     * @throws Exception if script does not exists
+     * @return [TerraformScript] if it exists
+     */
+    fun get(name: String): TerraformScript {
+        val script = File("$scriptFolder/$name")
+        if (!script.exists())
+            throw Exception(MSG_DIR_DOES_NOT_EXIST.format(name))
+        return TerraformScript(script, getParam(name))
+    }
+
+    /**
+     * Get script variables with values
+     * @param name of script
+     * @return the params of the script
+     */
+    protected fun getParam(name: String): TerraformScriptParams {
+        val paramsFile = File("$scriptFolder/$name/variables.tf.json")
+        if (!paramsFile.exists())
+            return TerraformScriptParams()
+        val parser: Parser = Parser()
+        val json: JsonObject = parser.parse(paramsFile.absolutePath) as JsonObject
+        val parameterMap = json["variable"] as JsonObject
+
+        val terraformScriptParams = TerraformScriptParams()
+        for ((k, v) in parameterMap) {
+            val paramMap = (v as JsonObject).map
+            val param = createTerraformParam(k, paramMap)
+            terraformScriptParams.add(param)
+        }
+        return terraformScriptParams
+    }
+}

--- a/src/main/kotlin/ru/jetbrains/testenvrunner/repository/StackFilesRepository.kt
+++ b/src/main/kotlin/ru/jetbrains/testenvrunner/repository/StackFilesRepository.kt
@@ -1,28 +1,15 @@
 package ru.jetbrains.testenvrunner.repository
 
 import com.beust.klaxon.JsonObject
-import com.beust.klaxon.Parser
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Repository
 import ru.jetbrains.testenvrunner.model.TerraformScript
+import ru.jetbrains.testenvrunner.model.TerraformScriptParams
 import java.io.File
-import java.io.FileFilter
 import java.io.IOException
 
 @Repository
-class StackFilesRepository constructor(@Value("\${stacks}") val stackFolder: String) {
-    //constants
-    val MSG_DIR_DOES_NOT_EXIST = ("The script %s does not exist in the system")
-
-    /**
-     * Get all running stacks
-     */
-    fun getAll(): List<TerraformScript> {
-        val directories = File(stackFolder).listFiles(FileFilter { it.isDirectory })
-        val scripts = directories.map { TerraformScript(it, getParam(it.name)) }
-        return scripts.toList()
-    }
-
+class StackFilesRepository constructor(@Value("\${stacks}") stackFolder: String) : ScriptRepository(stackFolder) {
     /**
      * Create stack that will be run
      * @param name - name of stack (it must be unique)
@@ -30,11 +17,11 @@ class StackFilesRepository constructor(@Value("\${stacks}") val stackFolder: Str
      * @param paramValues - running params of the script with values
      */
     fun create(name: String, template: TerraformScript, paramValues: Map<String, Any>): TerraformScript {
-        val dir = File("$stackFolder/$name")
+        val dir = File("$scriptFolder/$name")
         if (!dir.mkdir()) throw IOException("The directory already exists")
         template.scriptDir.listFiles().forEach { it.copyRecursively(File("${dir.absolutePath}/${it.name}")) }
         setParamValue(name, paramValues)
-        return TerraformScript(dir)
+        return TerraformScript(dir, TerraformScriptParams())
     }
 
     /**
@@ -46,27 +33,11 @@ class StackFilesRepository constructor(@Value("\${stacks}") val stackFolder: Str
         dir.deleteRecursively()
     }
 
-    fun get(name: String): TerraformScript {
-        val script = File("$stackFolder/$name")
-        if (!script.exists())
-            throw Exception(MSG_DIR_DOES_NOT_EXIST.format(name))
-        return TerraformScript(script, getParam(name))
-    }
 
     fun setParamValue(name: String, params: Map<String, Any>) {
         val json = JsonObject(params)
-        val fileParams = File("$stackFolder/$name/terraform.tfvars.json")
+        val fileParams = File("$scriptFolder/$name/terraform.tfvars.json")
         fileParams.createNewFile()
         fileParams.writeText(json.toJsonString(true))
-    }
-
-    private fun getParam(name: String): Map<String, Any?> {
-        val paramsFile = File("$stackFolder$name/variables.tf.json")
-        if (!paramsFile.exists())
-            return emptyMap()
-        val parser: Parser = Parser()
-        val json: JsonObject = parser.parse(paramsFile.absolutePath) as JsonObject
-        val parameterMap = json["variable"] as JsonObject
-        return parameterMap.map
     }
 }

--- a/src/main/kotlin/ru/jetbrains/testenvrunner/repository/TemplateRepository.kt
+++ b/src/main/kotlin/ru/jetbrains/testenvrunner/repository/TemplateRepository.kt
@@ -1,38 +1,9 @@
 package ru.jetbrains.testenvrunner.repository
 
-import com.beust.klaxon.JsonObject
-import com.beust.klaxon.Parser
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Repository
-import ru.jetbrains.testenvrunner.model.TerraformScript
-import java.io.File
-import java.io.FileFilter
 
 @Repository
-class TemplateRepository constructor(@Value("\${templates}") val scriptFolder: String) {
-    //consts
-    val MSG_DIR_DOES_NOT_EXIST = "The script %s does not exist in the system"
+class TemplateRepository constructor(@Value("\${templates}") templateFolder: String) : ScriptRepository(
+        templateFolder)
 
-    fun getAll(): List<TerraformScript> {
-        val directories = File(scriptFolder).listFiles(FileFilter { it.isDirectory })
-        val scripts = directories.map { TerraformScript(it, getParam(it.name)) }
-        return scripts.toList()
-    }
-
-    fun get(name: String): TerraformScript {
-        val script = File("$scriptFolder/$name")
-        if (!script.exists())
-            throw Exception(MSG_DIR_DOES_NOT_EXIST.format(name))
-        return TerraformScript(script, getParam(name))
-    }
-
-    private fun getParam(name: String): Map<String, Any?> {
-        val paramsFile = File("$scriptFolder/$name/variables.tf.json")
-        if (!paramsFile.exists())
-            return emptyMap()
-        val parser: Parser = Parser()
-        val json: JsonObject = parser.parse(paramsFile.absolutePath) as JsonObject
-        val parameterMap = json["variable"] as JsonObject
-        return parameterMap.map
-    }
-}

--- a/src/main/kotlin/ru/jetbrains/testenvrunner/service/DockerHubService.kt
+++ b/src/main/kotlin/ru/jetbrains/testenvrunner/service/DockerHubService.kt
@@ -1,0 +1,41 @@
+package ru.jetbrains.testenvrunner.service
+
+import com.beust.klaxon.JsonArray
+import com.beust.klaxon.JsonObject
+import com.beust.klaxon.Parser
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestTemplate
+import ru.jetbrains.testenvrunner.model.TerraformScript
+
+@Service
+class DockerHubService {
+    /**
+     * fill list of available tags for docker image if the terraform script has link
+     * @param terraformScript which available value params will be filled
+     */
+    fun fillAvailableDockerTags(terraformScript: TerraformScript) {
+        terraformScript.params.forEach {
+            if (it.dockerHub != "") it.availableValues = getAvailableTags(it.dockerHub)
+        }
+    }
+
+    /**
+     * Get available tags from Docker registry
+     * @param dockerImage - name of image
+     * @return list of available tags
+     */
+    private fun getAvailableTags(dockerImage: String): List<String> {
+        val restTemplate = RestTemplate()
+        val fooResourceUrl = "https://registry.hub.docker.com/v1/repositories/$dockerImage/tags"
+        val response = restTemplate.getForEntity(fooResourceUrl, String::class.java)
+
+        val json = Parser().parse(StringBuilder(response.body)) as JsonArray<*>
+
+        val availableVersions = mutableListOf<String>()
+        json.forEach {
+            val item = it as JsonObject
+            availableVersions.add(item["name"].toString())
+        }
+        return availableVersions
+    }
+}

--- a/src/main/kotlin/ru/jetbrains/testenvrunner/service/StackService.kt
+++ b/src/main/kotlin/ru/jetbrains/testenvrunner/service/StackService.kt
@@ -74,7 +74,6 @@ class StackService constructor(
     fun runStack(templateName: String, stackName: String, parameterMap: Map<String, String>,
                  user: User?): StackExecutor {
         val templateScript = templateRepository.get(templateName)
-
         if (user == null) {
             throw Exception("Sorry, you should bw logged before to run stack")
         }
@@ -117,6 +116,11 @@ class StackService constructor(
      */
     fun runStackError(stackExecutor: StackExecutor) {
         val stack = stackExecutor.stack
+        try {
+            destroyStack(stackExecutor.stack.name)
+        } catch (e: Exception) {
+            println(e.message + e.stackTrace)
+        }
         stackFilesRepository.remove(stack.name)
     }
 

--- a/src/main/resources/templates/async.html
+++ b/src/main/resources/templates/async.html
@@ -52,7 +52,6 @@
 
 <script type="text/javascript"
         src="webjars/jquery/3.2.1/jquery.min.js"></script>
-
 <script type="text/javascript" src="js/ajax_script_output.js"></script>
 
 </body>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -5,24 +5,12 @@
     <meta charset="UTF-8"/>
     <title>Title</title>
 
-    <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
-          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
-          crossorigin="anonymous"/>
-
-    <!-- Optional theme -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css"
-          integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp"
-          crossorigin="anonymous"/>
-
-    <!-- Latest compiled and minified JavaScript -->
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
-            integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
-            crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"/>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 </head>
 <body>
 <div class="container">
-
     <div class="masthead">
         <ul class="nav nav-pills pull-right">
             <!--/*@thymesVar id="user" type="ru.jetbrains.testenvrunner.model.User"*/-->

--- a/src/main/resources/templates/run_param.html
+++ b/src/main/resources/templates/run_param.html
@@ -5,23 +5,13 @@
     <meta charset="UTF-8"/>
     <title>Title</title>
 
-    <!-- Latest compiled and minified CSS -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
-          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u"
-          crossorigin="anonymous"/>
-
-    <!-- Optional theme -->
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css"
-          integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp"
-          crossorigin="anonymous"/>
-
-    <link rel="stylesheet" type="text/css" href="css/main.css"/>
-
-    <!-- Latest compiled and minified JavaScript -->
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
-            integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
-            crossorigin="anonymous"></script>
-
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"/>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.1/css/bootstrap-select.css"/>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.12.1/js/bootstrap-select.js"></script>
 </head>
 <body>
 <div class="container">
@@ -46,11 +36,20 @@
                     </div>
 
                     <div th:each="parameter : ${params}" class="form-group">
-                        <label th:text="${parameter.key}" th:for="${parameter.key}" class="col-xs-3 control-label">Parameter
-                            name</label>
+                        <label th:text="${parameter.name}" th:for="${parameter.name}" class="col-xs-3 control-label">
+                            Parameter name
+                        </label>
                         <div class="col-xs-5">
-                            <input class="form-control" th:value="${parameter.value['default']?:''}"
-                                   th:id="${parameter.key}" th:name="${parameter.key}" th:title="${parameter.key}"/>
+                            <select th:if="${!parameter.getAvailableValues().isEmpty()}"
+                                    class="selectpicker form-control" th:name="${parameter.name}"
+                                    data-live-search="true">
+                                <option th:each="value : ${parameter.getAvailableValues()}" th:value="${value}"
+                                        th:text="${value}"></option>
+                            </select>
+
+                            <input th:if="${parameter.getAvailableValues().isEmpty()}" class="form-control"
+                                   th:value="${parameter.defaultValue}"
+                                   th:name="${parameter.name}"/>
                         </div>
                     </div>
 

--- a/src/test/kotlin/ru/jetbrains/testenvrunner/repository/ScriptTest.kt
+++ b/src/test/kotlin/ru/jetbrains/testenvrunner/repository/ScriptTest.kt
@@ -10,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit4.SpringRunner
 import ru.jetbrains.testenvrunner.model.TerraformScript
+import ru.jetbrains.testenvrunner.model.TerraformScriptParams
 import java.io.File
 import java.io.IOException
 
@@ -29,6 +30,8 @@ open class ScriptTest : Assert() {
 
     val MSG_DIR_IS_NOT_DELETED = ("The script %s does not exist in the system")
 
+    protected fun emptyTerraformScriptParams() = TerraformScriptParams()
+
     protected fun addTempDir(name: String): File {
         return addFakeScriptDir(name, templFolder)
     }
@@ -37,9 +40,8 @@ open class ScriptTest : Assert() {
         removeAllInDir(templFolder)
     }
 
-
     protected fun addFakeTemplate(name: String, params: Map<String, Any> = emptyMap()): TerraformScript {
-        val script = TerraformScript(File("$templateFolder/$name"))
+        val script = TerraformScript(File("$templateFolder/$name"), emptyTerraformScriptParams())
         val dir = addFakeScriptDir(name, templateFolder)
         if (params.isEmpty()) return script
 
@@ -52,7 +54,7 @@ open class ScriptTest : Assert() {
     }
 
     protected fun addFakeStack(name: String, params: Map<String, Any> = emptyMap(), paramsValues: Map<String, Any> = emptyMap()): TerraformScript {
-        val script = TerraformScript(File("$stacksFolder/$name"))
+        val script = TerraformScript(File("$stacksFolder/$name"), emptyTerraformScriptParams())
         val dir = addFakeScriptDir(name, stacksFolder)
 
         if (params.isEmpty()) return script

--- a/src/test/kotlin/ru/jetbrains/testenvrunner/repository/StackFilesRepositoryTest.kt
+++ b/src/test/kotlin/ru/jetbrains/testenvrunner/repository/StackFilesRepositoryTest.kt
@@ -4,6 +4,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import ru.jetbrains.testenvrunner.model.TerraformScript
+import ru.jetbrains.testenvrunner.model.TerraformScriptParams
 import java.io.File
 import javax.inject.Inject
 import kotlin.test.assertFailsWith
@@ -22,8 +23,8 @@ class StackFilesRepositoryTest : ScriptTest() {
     fun getAllStacksList() {
         assertEquals("there are not all tests", 0, stackFilesRepository.getAll().size.toLong())
 
-        val scripts = listOf(TerraformScript(File("$stacksFolder/addAll1")),
-                TerraformScript(File("$stacksFolder/addAll2")))
+        val scripts = listOf(TerraformScript(File("$stacksFolder/addAll1"), emptyTerraformScriptParams()),
+                TerraformScript(File("$stacksFolder/addAll2"), emptyTerraformScriptParams()))
         scripts.forEach({ addFakeStack(it.name) })
 
         val actualScripts = stackFilesRepository.getAll()
@@ -39,7 +40,7 @@ class StackFilesRepositoryTest : ScriptTest() {
 
     @Test
     fun getStackTest() {
-        val script = TerraformScript(File("$stacksFolder/add"))
+        val script = TerraformScript(File("$stacksFolder/add"), TerraformScriptParams())
         addFakeStack(script.name)
         assertEquals("The gotten script is not the same with added", script, stackFilesRepository.get(script.name))
     }

--- a/src/test/kotlin/ru/jetbrains/testenvrunner/repository/TemplateRepositoryTest.kt
+++ b/src/test/kotlin/ru/jetbrains/testenvrunner/repository/TemplateRepositoryTest.kt
@@ -4,6 +4,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import ru.jetbrains.testenvrunner.model.TerraformScript
+import ru.jetbrains.testenvrunner.model.TerraformScriptParam
 import java.io.File
 import javax.inject.Inject
 import kotlin.test.assertFailsWith
@@ -22,8 +23,8 @@ class TemplateRepositoryTest : ScriptTest() {
     fun getAllScriptsList() {
         assertEquals("there are not all tests", 0, templateRepository.getAll().size.toLong())
 
-        val scripts = listOf(TerraformScript(File("$templateFolder/addAll1")),
-                TerraformScript(File("$templateFolder/addAll2")))
+        val scripts = listOf(TerraformScript(File("$templateFolder/addAll1"), emptyTerraformScriptParams()),
+                TerraformScript(File("$templateFolder/addAll2"), emptyTerraformScriptParams()))
         scripts.forEach { addFakeTemplate(it.name) }
 
         val actualScripts = templateRepository.getAll()
@@ -33,17 +34,20 @@ class TemplateRepositoryTest : ScriptTest() {
     @Test
     fun getScriptWithParamsTest() {
         val scriptName = "addparam"
-        val scriptFake = TerraformScript(File("$templateFolder/$scriptName"))
+        val scriptFake = TerraformScript(File("$templateFolder/$scriptName"), emptyTerraformScriptParams())
 
         val variables = mapOf("version" to mapOf("default" to "latest"))
         addFakeTemplate(scriptFake.name, variables)
         val script = templateRepository.get(scriptName)
-        assertEquals("Parameters are not the same", variables, script.params)
+
+        val expectedParams = emptyTerraformScriptParams()
+        expectedParams.add(TerraformScriptParam("version", defaultValue = "latest"))
+        assertEquals("Parameters are not the same", expectedParams, script.params)
     }
 
     @Test
     fun getScriptWithoutParamsTest() {
-        val script = TerraformScript(File("$templateFolder/add"))
+        val script = TerraformScript(File("$templateFolder/add"), emptyTerraformScriptParams())
         addFakeTemplate(script.name)
         assertEquals("The gotten script is not the same with added", script, templateRepository.get(script.name))
     }

--- a/src/test/kotlin/ru/jetbrains/testenvrunner/utils/TerraformExecutorServiceTest.kt
+++ b/src/test/kotlin/ru/jetbrains/testenvrunner/utils/TerraformExecutorServiceTest.kt
@@ -1,6 +1,5 @@
 package ru.jetbrains.testenvrunner.utils
 
-import org.junit.Assert
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.springframework.beans.factory.annotation.Value
@@ -8,6 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit4.SpringRunner
 import ru.jetbrains.testenvrunner.model.TerraformScript
+import ru.jetbrains.testenvrunner.repository.ScriptTest
 import ru.jetbrains.testenvrunner.service.TerraformExecutorService
 import java.io.File
 import javax.inject.Inject
@@ -15,7 +15,7 @@ import javax.inject.Inject
 @RunWith(SpringRunner::class)
 @SpringBootTest
 @TestPropertySource(locations = arrayOf("classpath:test.properties"))
-class TerraformExecutorServiceTest : Assert() {
+class TerraformExecutorServiceTest : ScriptTest() {
     @Inject
     lateinit var terraformExecutorService: TerraformExecutorService
 
@@ -24,7 +24,7 @@ class TerraformExecutorServiceTest : Assert() {
 
     @Test
     fun executeAndDestroyTerraformScriptSuccess() {
-        val script = TerraformScript(File(helloWorldScript))
+        val script = TerraformScript(File(helloWorldScript), emptyTerraformScriptParams())
         //check run
         val runScriptHandler = terraformExecutorService.applyTerraformScript(script)
         val runResult = runScriptHandler.executionResult

--- a/src/test/resources/terraform/hello-config/hello-world-config.tf
+++ b/src/test/resources/terraform/hello-config/hello-world-config.tf
@@ -2,6 +2,7 @@ provider "docker" {
 }
 resource "docker_image" "nginx" {
   name = "nginx:1.11-alpine"
+  keep_locally = true
 }
 
 resource "docker_container" "nginx" {

--- a/src/test/resources/terraform/mysql/script.tf
+++ b/src/test/resources/terraform/mysql/script.tf
@@ -3,6 +3,7 @@ provider "docker" {
 
 resource "docker_image" "mysql" {
   name = "mysql/mysql-server:${var.version}"
+  keep_locally = true
 }
 
 resource "docker_container" "mysql" {


### PR DESCRIPTION
The users often want to run the special version of docker image.
They do not want to search the right version by themselves. Add the ability
to load available tags of a docker image from the docker hub registry
and provide them as Select List with Life Search to users.